### PR TITLE
New check C0107: `typevar-name-mismatch`

### DIFF
--- a/doc/data/messages/t/typevar-name-mismatch/bad.py
+++ b/doc/data/messages/t/typevar-name-mismatch/bad.py
@@ -1,0 +1,1 @@
+X = TypeVar("T")  # [typevar-name-mismatch]

--- a/doc/data/messages/t/typevar-name-mismatch/good.py
+++ b/doc/data/messages/t/typevar-name-mismatch/good.py
@@ -1,0 +1,1 @@
+T = TypeVar("T")

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -382,6 +382,7 @@ class NameChecker(_BasicChecker):
         "assign-to-new-keyword",
         "typevar-name-incorrect-variance",
         "typevar-double-variance",
+        "typevar-name-mismatch",
     )
     def visit_assignname(self, node: nodes.AssignName) -> None:
         """Check module level assigned names."""

--- a/tests/functional/t/typevar_name_mismatch.py
+++ b/tests/functional/t/typevar_name_mismatch.py
@@ -1,0 +1,10 @@
+"""Test case for TypeVar name not matching assigned variable name."""
+from typing import TypeVar
+
+X = TypeVar("T")  # [typevar-name-mismatch]
+X_co = TypeVar("T", covariant=True)  # [typevar-name-mismatch]
+X_contra = TypeVar("T", contravariant=True)  # [typevar-name-mismatch]
+X_co, X_contra = (  # [typevar-name-mismatch,typevar-name-mismatch]
+    TypeVar("T", covariant=True),
+    TypeVar("T", contravariant=True),
+)

--- a/tests/functional/t/typevar_name_mismatch.txt
+++ b/tests/functional/t/typevar_name_mismatch.txt
@@ -1,0 +1,5 @@
+typevar-name-mismatch:4:0:4:1::"TypeVar must be assigned to a variable named ""T""":INFERENCE
+typevar-name-mismatch:5:0:5:4::"TypeVar must be assigned to a variable named ""T""":INFERENCE
+typevar-name-mismatch:6:0:6:8::"TypeVar must be assigned to a variable named ""T""":INFERENCE
+typevar-name-mismatch:7:0:7:4::"TypeVar must be assigned to a variable named ""T""":INFERENCE
+typevar-name-mismatch:7:6:7:14::"TypeVar must be assigned to a variable named ""T""":INFERENCE


### PR DESCRIPTION
Closes #5224. Emitted when a TypeVar is assigned to a variable that does not match its name argument. Builds on top of #6015